### PR TITLE
Disable exceptions from illegal email addresses

### DIFF
--- a/lib/cheetah/version.rb
+++ b/lib/cheetah/version.rb
@@ -1,3 +1,3 @@
 module Cheetah
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
As DevOps have been receiving many calls regarding invalid emails, we have been asked to disable them until a logging system is put in place. We are currently checking where Barclays wants these logs stored.
